### PR TITLE
feat: add itemsadder support for menu icons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,13 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+
+		<dependency>
+			<groupId>beer.devs</groupId>
+			<artifactId>itemsadder-api</artifactId>
+			<version>4.0.18-beta-10</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/items/ItemUtility.java
+++ b/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/items/ItemUtility.java
@@ -1,5 +1,6 @@
 package tfagaming.projects.minecraft.homestead.tools.minecraft.items;
 
+import dev.lone.itemsadder.api.CustomStack;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -77,6 +78,12 @@ public final class ItemUtility {
 	public static ItemStack getItem(String displayName, List<String> lore, Material material) {
 		if (material == null) material = Material.BARRIER;
 		ItemStack item = new ItemStack(material);
+		applyMeta(item, displayName, lore);
+		return item;
+	}
+
+	public static ItemStack getItem(String displayName, List<String> lore, CustomStack stack) {
+		ItemStack item = stack.getItemStack().clone();
 		applyMeta(item, displayName, lore);
 		return item;
 	}
@@ -200,4 +207,12 @@ public final class ItemUtility {
 		}
 		return head;
 	}
+
+    public static ItemStack getIAItem(String name, List<String> lore, CustomStack stack, Placeholder placeholder) {
+		return getItem(
+				Formatter.applyPlaceholders(name, placeholder),
+				applyPlaceholders(lore, placeholder),
+				stack
+		);
+    }
 }

--- a/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/menus/MenuUtility.java
+++ b/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/menus/MenuUtility.java
@@ -1,5 +1,6 @@
 package tfagaming.projects.minecraft.homestead.tools.minecraft.menus;
 
+import dev.lone.itemsadder.api.CustomStack;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.ItemStack;
@@ -115,6 +116,13 @@ public final class MenuUtility {
 						: ItemUtility.getItem(data.getName(), data.getLore(), Material.BARRIER, placeholder);
 			}
 			return ItemUtility.getPlayerHead(data.getName(), data.getLore(), texture, placeholder);
+		}
+
+		if(type.contains(":")){
+			CustomStack stack = CustomStack.getInstance(type.toLowerCase());
+			return stack !=null
+					? ItemUtility.getIAItem(data.getName(), data.getLore(), stack, placeholder)
+					: ItemUtility.getItem(data.getName(), data.getLore(), Material.BARRIER, placeholder);
 		}
 
 		if (type.startsWith("NEXOMC-") || type.startsWith("NEXO-")) {


### PR DESCRIPTION
Adds ItemsAdder support for custom menu icons. If the item id (namespace:id) is invalid defaults to vanilla barrier.