### PR TITLE
Custom item integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,13 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+
+		<dependency>
+			<groupId>beer.devs</groupId>
+			<artifactId>itemsadder-api</artifactId>
+			<version>4.0.18-beta-10</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,10 @@
 			<id>nexomc-releases</id>
 			<url>https://repo.nexomc.com/releases/</url>
 		</repository>
+		<repository>
+			<id>momirealms-repo</id>
+			<url>https://repo.momirealms.net/releases/</url>
+		</repository>
 	</repositories>
 
 	<dependencyManagement>
@@ -317,6 +321,20 @@
 			<groupId>beer.devs</groupId>
 			<artifactId>itemsadder-api</artifactId>
 			<version>4.0.18-beta-10</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>net.momirealms</groupId>
+			<artifactId>craft-engine-core</artifactId>
+			<version>26.7</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>net.momirealms</groupId>
+			<artifactId>craft-engine-bukkit</artifactId>
+			<version>26.7</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/tfagaming/projects/minecraft/homestead/integrations/CraftEngine.java
+++ b/src/main/java/tfagaming/projects/minecraft/homestead/integrations/CraftEngine.java
@@ -1,0 +1,35 @@
+package tfagaming.projects.minecraft.homestead.integrations;
+
+import net.momirealms.craftengine.bukkit.api.CraftEngineItems;
+import net.momirealms.craftengine.bukkit.item.BukkitItemDefinition;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import tfagaming.projects.minecraft.homestead.tools.java.Placeholder;
+import tfagaming.projects.minecraft.homestead.tools.minecraft.items.ItemUtility;
+import tfagaming.projects.minecraft.homestead.tools.minecraft.plugins.IntegrationUtility;
+
+import java.util.List;
+
+public class CraftEngine {
+
+    public static ItemStack getCEItem(String itemId, String displayname, List<String> lore, Placeholder placeholder) {
+        if (isAvailable()) {
+            BukkitItemDefinition definition = CraftEngineItems.byId(itemId);
+
+            ItemStack item = definition!= null? definition.buildBukkitItem().clone() : new ItemStack(Material.BARRIER);
+
+            return ItemUtility.applyMetadata(item, displayname, lore, placeholder);
+        }
+        return ItemUtility.applyMetadata(new ItemStack(Material.BARRIER), displayname, lore, placeholder);
+    }
+
+    public static boolean isAvailable() {
+        try {
+            Class.forName("net.momirealms.craftengine.bukkit.api.CraftEngineItems");
+
+            return IntegrationUtility.isEnabled(IntegrationUtility.Integration.CRAFTENGINE);
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/tfagaming/projects/minecraft/homestead/integrations/ItemsAdder.java
+++ b/src/main/java/tfagaming/projects/minecraft/homestead/integrations/ItemsAdder.java
@@ -19,7 +19,7 @@ public class ItemsAdder {
 
             return ItemUtility.applyMetadata(item, displayname, lore, placeholder);
         }
-        return new ItemStack(Material.BARRIER);
+        return ItemUtility.applyMetadata(new ItemStack(Material.BARRIER), displayname, lore, placeholder);
     }
 
     public static boolean isAvailable() {

--- a/src/main/java/tfagaming/projects/minecraft/homestead/integrations/ItemsAdder.java
+++ b/src/main/java/tfagaming/projects/minecraft/homestead/integrations/ItemsAdder.java
@@ -1,0 +1,34 @@
+package tfagaming.projects.minecraft.homestead.integrations;
+
+import dev.lone.itemsadder.api.CustomStack;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import tfagaming.projects.minecraft.homestead.tools.java.Placeholder;
+import tfagaming.projects.minecraft.homestead.tools.minecraft.items.ItemUtility;
+import tfagaming.projects.minecraft.homestead.tools.minecraft.plugins.IntegrationUtility;
+
+import java.util.List;
+
+public class ItemsAdder {
+
+    public static ItemStack getIAItem(String itemId, String displayname, List<String> lore, Placeholder placeholder) {
+        if (isAvailable()) {
+            CustomStack stack = CustomStack.getInstance(itemId.toLowerCase());
+
+            ItemStack item = stack!= null? stack.getItemStack().clone() : new ItemStack(Material.BARRIER);
+
+            return ItemUtility.applyMetadata(item, displayname, lore, placeholder);
+        }
+        return new ItemStack(Material.BARRIER);
+    }
+
+    public static boolean isAvailable() {
+        try {
+            Class.forName("dev.lone.itemsadder.api.CustomStack");
+
+            return IntegrationUtility.isEnabled(IntegrationUtility.Integration.ITEMSADDER);
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/tfagaming/projects/minecraft/homestead/integrations/NexoMC.java
+++ b/src/main/java/tfagaming/projects/minecraft/homestead/integrations/NexoMC.java
@@ -42,7 +42,7 @@ public final class NexoMC {
 			return ItemUtility.applyMetadata(item, displayname, lore, placeholder);
 		}
 
-		return new ItemStack(Material.BARRIER);
+		return ItemUtility.applyMetadata(new ItemStack(Material.BARRIER), displayname, lore, placeholder);
 	}
 
 	public static boolean isAvailable() {

--- a/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/items/ItemUtility.java
+++ b/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/items/ItemUtility.java
@@ -207,12 +207,4 @@ public final class ItemUtility {
 		}
 		return head;
 	}
-
-    public static ItemStack getIAItem(String name, List<String> lore, CustomStack stack, Placeholder placeholder) {
-		return getItem(
-				Formatter.applyPlaceholders(name, placeholder),
-				applyPlaceholders(lore, placeholder),
-				stack
-		);
-    }
 }

--- a/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/items/ItemUtility.java
+++ b/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/items/ItemUtility.java
@@ -1,5 +1,6 @@
 package tfagaming.projects.minecraft.homestead.tools.minecraft.items;
 
+import dev.lone.itemsadder.api.CustomStack;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -77,6 +78,12 @@ public final class ItemUtility {
 	public static ItemStack getItem(String displayName, List<String> lore, Material material) {
 		if (material == null) material = Material.BARRIER;
 		ItemStack item = new ItemStack(material);
+		applyMeta(item, displayName, lore);
+		return item;
+	}
+
+	public static ItemStack getItem(String displayName, List<String> lore, CustomStack stack) {
+		ItemStack item = stack.getItemStack().clone();
 		applyMeta(item, displayName, lore);
 		return item;
 	}
@@ -200,4 +207,12 @@ public final class ItemUtility {
 		}
 		return head;
 	}
+
+    public static ItemStack getIAItem(String name, List<String> lore, CustomStack stack, Placeholder placeholder) {
+		return getItem(
+				Formatter.applyPlaceholders(name, placeholder),
+				applyPlaceholders(lore, placeholder),
+				stack
+		);
+    }
 }

--- a/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/menus/MenuUtility.java
+++ b/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/menus/MenuUtility.java
@@ -1,5 +1,6 @@
 package tfagaming.projects.minecraft.homestead.tools.minecraft.menus;
 
+import dev.lone.itemsadder.api.CustomStack;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.ItemStack;
@@ -115,6 +116,13 @@ public final class MenuUtility {
 						: ItemUtility.getItem(data.getName(), data.getLore(), Material.BARRIER, placeholder);
 			}
 			return ItemUtility.getPlayerHead(data.getName(), data.getLore(), texture, placeholder);
+		}
+
+		if(type.contains(":")){
+			CustomStack stack = CustomStack.getInstance(type.toLowerCase());
+			return stack !=null
+					? ItemUtility.getIAItem(data.getName(), data.getLore(), stack, placeholder)
+					: ItemUtility.getItem(data.getName(), data.getLore(), Material.BARRIER, placeholder);
 		}
 
 		if (type.startsWith("NEXOMC-") || type.startsWith("NEXO-")) {

--- a/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/menus/MenuUtility.java
+++ b/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/menus/MenuUtility.java
@@ -1,9 +1,9 @@
 package tfagaming.projects.minecraft.homestead.tools.minecraft.menus;
 
-import dev.lone.itemsadder.api.CustomStack;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.ItemStack;
+import tfagaming.projects.minecraft.homestead.integrations.ItemsAdder;
 import tfagaming.projects.minecraft.homestead.integrations.NexoMC;
 import tfagaming.projects.minecraft.homestead.resources.ResourceType;
 import tfagaming.projects.minecraft.homestead.resources.Resources;
@@ -118,11 +118,9 @@ public final class MenuUtility {
 			return ItemUtility.getPlayerHead(data.getName(), data.getLore(), texture, placeholder);
 		}
 
-		if(type.contains(":")){
-			CustomStack stack = CustomStack.getInstance(type.toLowerCase());
-			return stack !=null
-					? ItemUtility.getIAItem(data.getName(), data.getLore(), stack, placeholder)
-					: ItemUtility.getItem(data.getName(), data.getLore(), Material.BARRIER, placeholder);
+		if(type.startsWith("IA-")){
+			String itemId = type.split("-", 2)[1];
+			return ItemsAdder.getIAItem(itemId, data.getName(), data.getLore(), placeholder);
 		}
 
 		if (type.startsWith("NEXOMC-") || type.startsWith("NEXO-")) {

--- a/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/menus/MenuUtility.java
+++ b/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/menus/MenuUtility.java
@@ -3,6 +3,7 @@ package tfagaming.projects.minecraft.homestead.tools.minecraft.menus;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.ItemStack;
+import tfagaming.projects.minecraft.homestead.integrations.CraftEngine;
 import tfagaming.projects.minecraft.homestead.integrations.ItemsAdder;
 import tfagaming.projects.minecraft.homestead.integrations.NexoMC;
 import tfagaming.projects.minecraft.homestead.resources.ResourceType;
@@ -126,6 +127,10 @@ public final class MenuUtility {
 		if (type.startsWith("NEXOMC-") || type.startsWith("NEXO-")) {
 			String itemId = type.split("-", 2)[1];
 			return NexoMC.getNexoItem(itemId, data.getName(), data.getLore(), placeholder);
+		}
+		if(type.startsWith("CE-")){
+			String itemId = type.split("-", 2)[1];
+			return CraftEngine.getCEItem(itemId, data.getName(), data.getLore(), placeholder);
 		}
 
 		Material material = Material.getMaterial(type);

--- a/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/plugins/IntegrationUtility.java
+++ b/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/plugins/IntegrationUtility.java
@@ -25,7 +25,8 @@ public final class IntegrationUtility {
 		SQUAREMAP("squaremap"),
 		BLUEMAP("BlueMap"),
 		NEXO("Nexo"),
-		ITEMSADDER("ItemsAdder");
+		ITEMSADDER("ItemsAdder"),
+		CRAFTENGINE("CraftEngine");
 
 
 		private final String name;

--- a/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/plugins/IntegrationUtility.java
+++ b/src/main/java/tfagaming/projects/minecraft/homestead/tools/minecraft/plugins/IntegrationUtility.java
@@ -24,7 +24,9 @@ public final class IntegrationUtility {
 		PL3XMAP("Pl3xMap"),
 		SQUAREMAP("squaremap"),
 		BLUEMAP("BlueMap"),
-		NEXO("Nexo");
+		NEXO("Nexo"),
+		ITEMSADDER("ItemsAdder");
+
 
 		private final String name;
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ author: TayebYassine
 api-version: 1.21.10
 folia-supported: true
 depend: [ Vault ]
-softdepend: [ VaultUnlocked, Essentials, EssentialsX, CMI, TheNewEconomy, Polyconomy, iConomyUnlocked, BlueMap, squaremap, dynmap, Pl3xMap ]
+softdepend: [ VaultUnlocked, Essentials, EssentialsX, CMI, TheNewEconomy, Polyconomy, iConomyUnlocked, BlueMap, squaremap, dynmap, Pl3xMap, ItemsAdder ]
 commands:
   claim:
     description: 'Claim a chunk using Homestead'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ author: TayebYassine
 api-version: 1.21.10
 folia-supported: true
 depend: [ Vault ]
-softdepend: [ VaultUnlocked, Essentials, EssentialsX, CMI, TheNewEconomy, Polyconomy, iConomyUnlocked, BlueMap, squaremap, dynmap, Pl3xMap, ItemsAdder ]
+softdepend: [ VaultUnlocked, Essentials, EssentialsX, CMI, TheNewEconomy, Polyconomy, iConomyUnlocked, BlueMap, squaremap, dynmap, Pl3xMap, ItemsAdder, CraftEngine ]
 commands:
   claim:
     description: 'Claim a chunk using Homestead'


### PR DESCRIPTION
Adds ItemsAdder and CraftEngine support for custom menu items. If the plugin is not present or the item id is invalid returns a barrier as default. 

Fixed an issue where the default item's title and lore were not set when NexoMC is not present on the server.
<img width="521" height="306" alt="issue" src="https://github.com/user-attachments/assets/c4185f5c-e548-4bc1-a2ee-0714313653d4" />

Tested with both ItemsAdder and CraftEngine
